### PR TITLE
Add FAQs page

### DIFF
--- a/lib/bottom_bar.dart
+++ b/lib/bottom_bar.dart
@@ -87,7 +87,7 @@ class BottomBar extends StatelessWidget {
       @required Function onTap,
       @required Color color}) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 5),
       child: Center(
           child: MouseRegion(
         cursor: SystemMouseCursors.click,

--- a/lib/bottom_bar.dart
+++ b/lib/bottom_bar.dart
@@ -7,6 +7,8 @@ final Launcher launcher = Launcher();
 
 // ignore: must_be_immutable
 class BottomBar extends StatelessWidget {
+  VoidCallback _onFAQsTap;
+
   List socialPlatforms = [
     {
       'URL': 'https://github.com/himanshusharma89/flutterx100',
@@ -17,6 +19,9 @@ class BottomBar extends StatelessWidget {
       'iconURL': 'https://img.icons8.com/color/48/000000/twitter.png'
     },
   ];
+
+  BottomBar(this._onFAQsTap);
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -33,6 +38,8 @@ class BottomBar extends StatelessWidget {
                 ));
               },
               color: Colors.white),
+          bottomBarItem(
+              title: 'FAQs', onTap: this._onFAQsTap, color: Colors.white),
           bottomBarItem(
               title: 'Community',
               onTap: () {

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -73,6 +73,8 @@ class _DashboardState extends State<Dashboard> {
         ],
       );
 
-  void onLogoTap() => this.pageController.jumpToPage(0);
-  void onFAQsTap() => this.pageController.jumpToPage(1);
+  void onLogoTap() => this.pageController.animateToPage(0,
+      duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
+  void onFAQsTap() => this.pageController.animateToPage(1,
+      duration: Duration(milliseconds: 300), curve: Curves.easeInOut);
 }

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -53,24 +53,23 @@ class _DashboardState extends State<Dashboard> {
         ],
       );
 
-  Widget get mobileBody => PageView(
-        controller: pageController,
-        scrollDirection: Axis.vertical,
-        physics: NeverScrollableScrollPhysics(),
+  Widget get mobileBody => Stack(
         children: [
-          Stack(
-            children: [
-              ListView(
-                controller: scrollController,
-                children: [Welcome(), Intro()],
-              ),
-              Align(
-                alignment: Alignment.bottomCenter,
-                child: BottomBar(onFAQsTap),
-              )
-            ],
-          ),
-          FAQs(),
+          PageView(
+              controller: pageController,
+              scrollDirection: Axis.vertical,
+              physics: NeverScrollableScrollPhysics(),
+              children: [
+                ListView(
+                  controller: scrollController,
+                  children: [Welcome(), Intro()],
+                ),
+                FAQs(),
+              ]),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: BottomBar(onFAQsTap),
+          )
         ],
       );
 

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx100/bottom_bar.dart';
 import 'package:flutterx100/responsive_layout.dart';
@@ -29,7 +28,7 @@ class _DashboardState extends State<Dashboard> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        appBar: TopBar(onFAQsTap),
+        appBar: TopBar(onLogoTap, onFAQsTap),
         body: ResponsiveLayout.isLargeScreen(context) ||
                 ResponsiveLayout.isMediumScreen(context)
             ? desktopBody
@@ -54,18 +53,27 @@ class _DashboardState extends State<Dashboard> {
         ],
       );
 
-  Widget get mobileBody => Stack(
+  Widget get mobileBody => PageView(
+        controller: pageController,
+        scrollDirection: Axis.vertical,
+        physics: new NeverScrollableScrollPhysics(),
         children: [
-          ListView(
-            controller: scrollController,
-            children: [Welcome(), Intro()],
+          Stack(
+            children: [
+              ListView(
+                controller: scrollController,
+                children: [Welcome(), Intro()],
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: BottomBar(onFAQsTap),
+              )
+            ],
           ),
-          Align(
-            alignment: Alignment.bottomCenter,
-            child: BottomBar(),
-          )
+          FAQs(),
         ],
       );
 
+  void onLogoTap() => this.pageController.jumpToPage(0);
   void onFAQsTap() => this.pageController.jumpToPage(1);
 }

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -5,6 +5,7 @@ import 'package:flutterx100/responsive_layout.dart';
 import 'package:flutterx100/screens/intro.dart';
 import 'package:flutterx100/screens/welcome.dart';
 
+import 'screens/faqs.dart';
 import 'top_bar.dart';
 
 class Dashboard extends StatefulWidget {
@@ -49,10 +50,7 @@ class _DashboardState extends State<Dashboard> {
               children: [Welcome(), Intro()],
             ),
           ),
-          Container(
-            color: Colors.blue,
-            child: Text("derp"),
-          )
+          FAQs(),
         ],
       );
 
@@ -69,7 +67,5 @@ class _DashboardState extends State<Dashboard> {
         ],
       );
 
-  void onFAQsTap() {
-    this.pageController.jumpToPage(1);
-  }
+  void onFAQsTap() => this.pageController.jumpToPage(1);
 }

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterx100/bottom_bar.dart';
 import 'package:flutterx100/responsive_layout.dart';
@@ -13,6 +14,9 @@ class Dashboard extends StatefulWidget {
 
 class _DashboardState extends State<Dashboard> {
   ScrollController scrollController;
+  PageController pageController = PageController(
+    initialPage: 0,
+  );
 
   @override
   void initState() {
@@ -24,29 +28,48 @@ class _DashboardState extends State<Dashboard> {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        appBar: TopBar(),
+        appBar: TopBar(onFAQsTap),
         body: ResponsiveLayout.isLargeScreen(context) ||
                 ResponsiveLayout.isMediumScreen(context)
-            ? Scrollbar(
-                controller: scrollController,
-                child: ListView(
-                  controller: scrollController,
-                  children: [Welcome(), Intro()],
-                ),
-              )
-            : Stack(
-              children: [
-                ListView(
-                    controller: scrollController,
-                    children: [Welcome(), Intro()],
-                  ),
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: BottomBar(),
-                )
-              ],
-            ),
+            ? desktopBody
+            : mobileBody,
       ),
     );
+  }
+
+  Widget get desktopBody => PageView(
+        controller: pageController,
+        scrollDirection: Axis.vertical,
+        physics: new NeverScrollableScrollPhysics(),
+        children: [
+          Scrollbar(
+            controller: scrollController,
+            child: ListView(
+              controller: scrollController,
+              children: [Welcome(), Intro()],
+            ),
+          ),
+          Container(
+            color: Colors.blue,
+            child: Text("derp"),
+          )
+        ],
+      );
+
+  Widget get mobileBody => Stack(
+        children: [
+          ListView(
+            controller: scrollController,
+            children: [Welcome(), Intro()],
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: BottomBar(),
+          )
+        ],
+      );
+
+  void onFAQsTap() {
+    this.pageController.jumpToPage(1);
   }
 }

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -40,7 +40,7 @@ class _DashboardState extends State<Dashboard> {
   Widget get desktopBody => PageView(
         controller: pageController,
         scrollDirection: Axis.vertical,
-        physics: new NeverScrollableScrollPhysics(),
+        physics: NeverScrollableScrollPhysics(),
         children: [
           Scrollbar(
             controller: scrollController,
@@ -56,7 +56,7 @@ class _DashboardState extends State<Dashboard> {
   Widget get mobileBody => PageView(
         controller: pageController,
         scrollDirection: Axis.vertical,
-        physics: new NeverScrollableScrollPhysics(),
+        physics: NeverScrollableScrollPhysics(),
         children: [
           Stack(
             children: [

--- a/lib/dashboard.dart
+++ b/lib/dashboard.dart
@@ -39,7 +39,7 @@ class _DashboardState extends State<Dashboard> {
 
   Widget get desktopBody => PageView(
         controller: pageController,
-        scrollDirection: Axis.vertical,
+        scrollDirection: Axis.horizontal,
         physics: NeverScrollableScrollPhysics(),
         children: [
           Scrollbar(

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutterx100/bottom_bar.dart';
 import 'package:flutterx100/launcher.dart';
 import 'package:flutterx100/responsive_layout.dart';
 
@@ -67,35 +68,42 @@ class FAQs extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
-    return ListView(
-      shrinkWrap: false,
-      children: [
-        Padding(
-          padding: EdgeInsets.symmetric(
-              vertical: 30,
-              horizontal: ResponsiveLayout.isSmallScreen(context) ? 60 : 300),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                'Frequently Asked Questions',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 30,
+    return Stack(children: [
+      ListView(
+        shrinkWrap: false,
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(
+                vertical: 30,
+                horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 300),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  'Frequently Asked Questions',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 30,
+                  ),
                 ),
-              ),
-              SizedBox(
-                height: height * 0.02,
-              ),
-              ...getFAQs(),
-              SizedBox(
-                height: height * 0.1,
-              ),
-            ],
+                SizedBox(
+                  height: height * 0.02,
+                ),
+                ...getFAQs(),
+                SizedBox(
+                  height: height * 0.1,
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
-    );
+        ],
+      ),
+      if (ResponsiveLayout.isSmallScreen(context))
+        Align(
+          alignment: Alignment.bottomCenter,
+          child: BottomBar(() => {}),
+        )
+    ]);
   }
 
   List<Widget> getFAQs() => _faqs.map((e) => getFAQ(e)).toList();

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -6,6 +6,7 @@ final Launcher launcher = Launcher();
 
 // ignore: must_be_immutable
 class FAQs extends StatelessWidget {
+  final ScrollController _scrollController = ScrollController();
   List _faqs = [
     {
       'question':
@@ -67,34 +68,39 @@ class FAQs extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
-    return ListView(
-      shrinkWrap: false,
-      children: [
-        Padding(
-          padding: EdgeInsets.symmetric(
-              vertical: 30,
-              horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 200),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                'Frequently Asked Questions',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 30,
+    return Scrollbar(
+      controller: _scrollController,
+      isAlwaysShown: true,
+      child: ListView(
+        controller: _scrollController,
+        shrinkWrap: false,
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(
+                vertical: 30,
+                horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 200),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Text(
+                  'Frequently Asked Questions',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 30,
+                  ),
                 ),
-              ),
-              SizedBox(
-                height: height * 0.02,
-              ),
-              ...getFAQs(),
-              SizedBox(
-                height: height * 0.1,
-              ),
-            ],
+                SizedBox(
+                  height: height * 0.02,
+                ),
+                ...getFAQs(),
+                SizedBox(
+                  height: height * 0.1,
+                ),
+              ],
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutterx100/launcher.dart';
+import 'package:flutterx100/responsive_layout.dart';
+
+final Launcher launcher = Launcher();
+
+// ignore: must_be_immutable
+class FAQs extends StatelessWidget {
+  List _faqs = [
+    {
+      'question':
+          'How do I connect with the people who are also doing this challenge?',
+      'answer':
+          'Search for #100DaysOfCode on Twitter :) Also, for other ways to connect, go to the Connect page'
+    },
+    {
+      'question':
+          'I am new to coding (or just deciding to learn to code) and can’t build projects yet, what should I do?',
+      'answer':
+          'The best way to start would be to follow the FreeCodeCamp’s Front End Curriculum from the very beginning. The further you get during the 100 days, the better.'
+    },
+    {
+      'question':
+          'I’ve already started the challenge, and I’m currently on Day 8 [*for example]. How can I start using this repo to track my progress?',
+      'answer':
+          'Don’t worry. Restore as much info on the previous days, but if you can’t then just continue from where you are right now. If you have been tweeting about your progress every day, put the links to your tweets in the Log for each day. Then, follow the format.'
+    },
+    {
+      'question': 'I’ve missed a day, does it mean I’ve failed the challenge?',
+      'answer':
+          'Absolutely not. You are allowed to miss one day (then make it up by adding one more day to the end of the 100), but never miss two days in a row. This is a great piece of advice on habit formation that I got from Leo Babauta at zen habits.'
+    },
+    {
+      'question':
+          'I come home late, and by the time I am finished with my hour, it’s past midnight, does it count?',
+      'answer':
+          'Of course it counts! The rule of thumb is: have you coded for at least an hour before going to sleep that day? If yes, you are on track. The reason for this is that we all have different schedules and different life periods (kids, school, work, and what have you) so don’t hold yourself to some arbitrary time standard. You will not experience what Cinderella experienced once the clock strikes midnight. Don’t worry whether you get a point on GitHub on that particular day. Yes, it’s nice to have them in a streak one by one, but don’t do yourself a disservice by measuring your efforts to a clock.'
+    },
+    {
+      'question': 'Should I keep a journal?',
+      'answer':
+          'Yes you should, and the best way to do that is to fork this repo, and commit to the Log daily. It’s helpful in two major ways: you will be able to look at the progress each day and see how far you’ve already come and it will be easier to find the motivation to continue, and the second one is that after you’ve done your 100 days, you will be able to analyze your experience better and see what worked and what didn’t.'
+    },
+    {
+      'question': 'Should I put my projects online?',
+      'answer':
+          'Definitely. It’s great for accountability and motivation to know that the stuff you’ve worked on is accessible online to anyone who may wish to look at it. It will make you care about the end product more, and will lead to a more impressive result in the end. I suggest you put them on GitHub.'
+    },
+    {
+      'question': 'Should I worry about streaks?',
+      'answer':
+          'Streaks are nice and helpful, but as I mentioned above — don’t worry about them too much and don’t criticize yourself over missing a day. Instead, make sure you do everything to not let that happen again, and know that worrying and scolding yourself will not give you any results. (Ok, It will give you results, but only negative. I would call them consequences, not results) The best way to get out of that negative emotional state is to sit down and code.'
+    },
+    {
+      'question': 'What is the most difficult part of this challenge?',
+      'answer':
+          'The part where you have to sit down and start coding. Don’t postpone that or think about it at all, because you will rationalize yourself out of it. Approach it mechanically: sit down, open your laptop, launch your coding editor, and start typing. After 5 minutes, you will not feel any problems/procrastination/desire to stop.'
+    },
+    {
+      'question':
+          'If everyone started on a certain day, should I join them on the day they are? For example, from Day 12?',
+      'answer':
+          'This challenge is individual, so when you join you start at day 1. Whenever you’ll be posting an update on Twitter or elsewhere, make sure to mention which day you are on and use the hashtag so that people can find and support you!'
+    },
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final height = MediaQuery.of(context).size.height;
+    return PageView(
+      scrollDirection: Axis.vertical,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+              vertical: 30,
+              horizontal: ResponsiveLayout.isSmallScreen(context) ? 60 : 100),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                'Frequently Asked Questions',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 30,
+                ),
+              ),
+              SizedBox(
+                height: height * 0.02,
+              ),
+              // ..._faqs.map((e) => getFAQ(e)).toList(),
+              ...getFAQs(),
+              SizedBox(
+                height: height * 0.1,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<Widget> getFAQs() => _faqs.map((e) => getFAQ(e)).toList();
+
+  Widget getFAQ(dynamic faq) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          Text(
+            "Q: ${faq['question']}. ",
+            textAlign: TextAlign.left,
+            style: TextStyle(fontSize: 18),
+          ),
+          SizedBox(
+            height: 10,
+          ),
+          Text(
+            "A: ${faq['answer']}. ",
+            textAlign: TextAlign.left,
+            style: TextStyle(fontSize: 18),
+          ),
+          SizedBox(
+            height: 20,
+          ),
+          Divider(
+            color: Colors.black,
+            height: 1,
+            thickness: 1,
+            indent: 0,
+            endIndent: 0,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -67,13 +67,13 @@ class FAQs extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
-    return PageView(
-      scrollDirection: Axis.vertical,
+    return ListView(
+      shrinkWrap: false,
       children: [
         Padding(
           padding: EdgeInsets.symmetric(
               vertical: 30,
-              horizontal: ResponsiveLayout.isSmallScreen(context) ? 60 : 100),
+              horizontal: ResponsiveLayout.isSmallScreen(context) ? 60 : 300),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
@@ -87,7 +87,6 @@ class FAQs extends StatelessWidget {
               SizedBox(
                 height: height * 0.02,
               ),
-              // ..._faqs.map((e) => getFAQ(e)).toList(),
               ...getFAQs(),
               SizedBox(
                 height: height * 0.1,
@@ -124,13 +123,14 @@ class FAQs extends StatelessWidget {
           SizedBox(
             height: 20,
           ),
-          Divider(
-            color: Colors.black,
-            height: 1,
-            thickness: 1,
-            indent: 0,
-            endIndent: 0,
-          ),
+          if (_faqs.indexOf(faq) != _faqs.length - 1)
+            Divider(
+              color: Colors.black,
+              height: 1,
+              thickness: 1,
+              indent: 0,
+              endIndent: 0,
+            ),
         ],
       ),
     );

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -75,7 +75,7 @@ class FAQs extends StatelessWidget {
           Padding(
             padding: EdgeInsets.symmetric(
                 vertical: 30,
-                horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 300),
+                horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 200),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [

--- a/lib/screens/faqs.dart
+++ b/lib/screens/faqs.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutterx100/bottom_bar.dart';
 import 'package:flutterx100/launcher.dart';
 import 'package:flutterx100/responsive_layout.dart';
 
@@ -68,42 +67,35 @@ class FAQs extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final height = MediaQuery.of(context).size.height;
-    return Stack(children: [
-      ListView(
-        shrinkWrap: false,
-        children: [
-          Padding(
-            padding: EdgeInsets.symmetric(
-                vertical: 30,
-                horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 200),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                Text(
-                  'Frequently Asked Questions',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 30,
-                  ),
+    return ListView(
+      shrinkWrap: false,
+      children: [
+        Padding(
+          padding: EdgeInsets.symmetric(
+              vertical: 30,
+              horizontal: ResponsiveLayout.isSmallScreen(context) ? 30 : 200),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                'Frequently Asked Questions',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 30,
                 ),
-                SizedBox(
-                  height: height * 0.02,
-                ),
-                ...getFAQs(),
-                SizedBox(
-                  height: height * 0.1,
-                ),
-              ],
-            ),
+              ),
+              SizedBox(
+                height: height * 0.02,
+              ),
+              ...getFAQs(),
+              SizedBox(
+                height: height * 0.1,
+              ),
+            ],
           ),
-        ],
-      ),
-      if (ResponsiveLayout.isSmallScreen(context))
-        Align(
-          alignment: Alignment.bottomCenter,
-          child: BottomBar(() => {}),
-        )
-    ]);
+        ),
+      ],
+    );
   }
 
   List<Widget> getFAQs() => _faqs.map((e) => getFAQ(e)).toList();

--- a/lib/top_bar.dart
+++ b/lib/top_bar.dart
@@ -9,6 +9,8 @@ final Launcher launcher = Launcher();
 
 // ignore: must_be_immutable
 class TopBar extends StatelessWidget with PreferredSizeWidget {
+  VoidCallback _onFAQsTap;
+
   List socialPlatforms = [
     {
       'URL': 'https://github.com/himanshusharma89/flutterx100',
@@ -19,6 +21,8 @@ class TopBar extends StatelessWidget with PreferredSizeWidget {
       'iconURL': 'https://img.icons8.com/color/48/000000/twitter.png'
     },
   ];
+
+  TopBar(this._onFAQsTap);
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight + 10);
@@ -74,6 +78,7 @@ class TopBar extends StatelessWidget with PreferredSizeWidget {
                             duration: Duration(milliseconds: 4000),
                           ));
                         }),
+                    topBarItem(title: 'FAQs', onTap: this._onFAQsTap),
                     topBarItem(
                         title: 'Community',
                         onTap: () {

--- a/lib/top_bar.dart
+++ b/lib/top_bar.dart
@@ -9,6 +9,7 @@ final Launcher launcher = Launcher();
 
 // ignore: must_be_immutable
 class TopBar extends StatelessWidget with PreferredSizeWidget {
+  VoidCallback _onLogoTap;
   VoidCallback _onFAQsTap;
 
   List socialPlatforms = [
@@ -22,7 +23,7 @@ class TopBar extends StatelessWidget with PreferredSizeWidget {
     },
   ];
 
-  TopBar(this._onFAQsTap);
+  TopBar(this._onLogoTap, this._onFAQsTap);
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight + 10);
@@ -45,25 +46,32 @@ class TopBar extends StatelessWidget with PreferredSizeWidget {
                 ? MainAxisAlignment.center
                 : MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 5),
-                    child: FadeInImage(
-                      height: kToolbarHeight,
-                      width: kToolbarHeight,
-                      image: AssetImage('assets/flutter.png'),
-                      placeholder: AssetImage('assets/Blocks.gif'),
-                    ),
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  onTap: this._onLogoTap,
+                  child: Row(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 5),
+                        child: FadeInImage(
+                          height: kToolbarHeight,
+                          width: kToolbarHeight,
+                          image: AssetImage('assets/flutter.png'),
+                          placeholder: AssetImage('assets/Blocks.gif'),
+                        ),
+                      ),
+                      SizedBox(
+                        width: 5,
+                      ),
+                      Text(
+                        '100DaysOfFlutter',
+                        style: TextStyle(
+                            fontSize: 18, fontWeight: FontWeight.w600),
+                      ),
+                    ],
                   ),
-                  SizedBox(
-                    width: 5,
-                  ),
-                  Text(
-                    '100DaysOfFlutter',
-                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
-                  ),
-                ],
+                ),
               ),
               if (ResponsiveLayout.isLargeScreen(context) ||
                   ResponsiveLayout.isMediumScreen(context))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,35 +7,35 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   cloud_firestore:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   ffi:
     dependency: transitive
     description:
@@ -183,21 +183,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
@@ -279,49 +279,49 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -370,7 +370,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   win32:
     dependency: transitive
     description:
@@ -386,5 +386,5 @@ packages:
     source: hosted
     version: "0.1.2"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
I've addressed issue #21 with the changes in this pull request. Per @himanshusharma89's request I've used `PageView` to achieve navigating to the FAQs content. I've locked the gesture switching on the `PageView` and instead require tapping on menu items to jump between pages. This requires `VoidCallback` parameters to be passed to the `BottomBar` and `TopBar` widgets, so that the logic to jump between pages can be provided by the `Dashboard` widget. 

I've tested these changes in Chrome across small, medium, and large displays to ensure the functionality works, and the content is displayed properly in al scenarios.